### PR TITLE
Fix computation of new tag index with cached one

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -16,6 +16,7 @@ local awful = require("awful")
 local wibox = require("wibox")
 local pairs = pairs
 local io = io
+local math = math
 local tonumber = tonumber
 local dbg= dbg
 local capi = {
@@ -339,7 +340,7 @@ function set(t, args)
         idx = pos2idx(props.position, scr)
         if t_idx and t_idx < idx then idx = idx - 1 end
     elseif shifty.config.remember_index and index_cache[scr][t.name] then
-        idx = index_cache[scr][t.name]
+        idx = math.min(index_cache[scr][t.name], #tags+1)
     elseif not t_idx then
         idx = #tags + 1
     end


### PR DESCRIPTION
Re-opening an already closed tag with high index after closing some low index tag leads to an error in the index computation for the `table.insert` call.

For example:
- I have 3 tags, A, B, C, with respective index 1, 2, 3.
- I close C => It's cached index is 3 and length of the tags list is 2
- I close B => length of the tags list is 1
- I try to re-open C => In the `set` function, `idx` is computed from the cache list to 3, and so you try to insert a tag at index 3 in a list of length 1 which leads to an error.

I fix this by computing idx as the minimum between the cached value and the length of the tags list (plus one).
